### PR TITLE
Fix Booking homepage image paths

### DIFF
--- a/sites/booking/templates/index.html
+++ b/sites/booking/templates/index.html
@@ -220,7 +220,7 @@
         </div>
         <div class="card-grid cards-3">
             <a href="{{ url_for('article_detail', slug='top-5-european-cities-food-lovers') }}" class="city-card">
-                <img src="/static/images/gallery/paris/paris_1.jpg" alt="European food cities" class="city-card-img"
+                <img src="/static/images/screenshots/paris.png" alt="European food cities" class="city-card-img"
                      onerror="this.style.background='linear-gradient(135deg,#003580,#006ce4)';this.alt=''">
                 <div class="city-card-body">
                     <h3>Top 5 European Cities for Food Lovers</h3>
@@ -228,7 +228,7 @@
                 </div>
             </a>
             <a href="{{ url_for('article_detail', slug='asia-on-a-budget') }}" class="city-card">
-                <img src="/static/images/gallery/bali/bali_1.jpg" alt="Asia on a budget" class="city-card-img"
+                <img src="/static/images/screenshots/bali.png" alt="Asia on a budget" class="city-card-img"
                      onerror="this.style.background='linear-gradient(135deg,#003580,#006ce4)';this.alt=''">
                 <div class="city-card-body">
                     <h3>Asia on a Budget: 10 Nights Under $60 a Day</h3>
@@ -236,7 +236,7 @@
                 </div>
             </a>
             <a href="{{ url_for('article_detail', slug='romantic-city-breaks') }}" class="city-card">
-                <img src="/static/images/gallery/paris/paris_2.jpg" alt="Romantic city breaks" class="city-card-img"
+                <img src="/static/images/screenshots/rome.png" alt="Romantic city breaks" class="city-card-img"
                      onerror="this.style.background='linear-gradient(135deg,#003580,#006ce4)';this.alt=''">
                 <div class="city-card-body">
                     <h3>Seven Romantic City Breaks for Couples</h3>


### PR DESCRIPTION
## Summary

Fixes the three broken travel-inspiration images on the Booking homepage by pointing the template at image files that already exist in the current WebHarbor assets.

## Root Cause

`sites/booking/templates/index.html` hardcoded these missing paths:

- `/static/images/gallery/paris/paris_1.jpg`
- `/static/images/gallery/bali/bali_1.jpg`
- `/static/images/gallery/paris/paris_2.jpg`

The latest Docker image does not contain those files, so the Booking homepage emits three 404s.

## Change

Replaced the missing gallery paths with existing screenshot assets:

- `/static/images/screenshots/paris.png`
- `/static/images/screenshots/bali.png`
- `/static/images/screenshots/rome.png`

## Validation

- `python3 -m py_compile sites/booking/app.py`
- Verified the replacement assets exist in the current WebHarbor runtime image.
- Applied the same change to a local running container and verified the Booking homepage has 0 broken images / 0 4xx static responses.

## Related

Partially addresses #3. ESPN still needs missing league/team image assets or a separate fallback change.
