### PR TITLE
Fix user-visible mirror URL leaks

### DIFF
--- a/docs/url-realism-audit.md
+++ b/docs/url-realism-audit.md
@@ -1,0 +1,103 @@
+# URL Realism Audit
+
+## Scope
+
+This audit covers user-visible URL surfaces in WebHarbor mirror sites: share
+links, copy-link buttons, hidden post-action return URLs, and middleware that
+rewrites external hosts into a local mirror. Benchmark task entry points are
+out of scope because `sites/*/tasks.jsonl` intentionally points agents at
+`http://localhost:40000` through `http://localhost:40014`.
+
+## Findings
+
+### Google Map Share And Website URLs
+
+The Google Map place detail share box rendered a local mirror URL:
+
+```text
+http://localhost:40008/place/<slug>
+```
+
+The same site seeded many place website rows as `https://example.com/<slug>`.
+Both values could be exposed in the user-facing place detail page.
+
+Fix:
+
+- The share box now uses a real Google Maps place URL:
+
+```text
+https://www.google.com/maps/place/<place+city>/
+```
+
+- Future Google Map seed data writes Google Maps place URLs instead of
+  `example.com` placeholders.
+- Runtime rendering falls back to the Google Maps place URL when an existing
+  packaged seed database still contains an `example.com` placeholder.
+
+### Booking And Allrecipes Return URLs
+
+Several save buttons wrote `{{ request.url }}` into hidden `next` inputs. In a
+local mirror this serializes an absolute local URL such as
+`http://localhost:40005/...` into the DOM. That URL is not a real upstream URL
+and also makes post-action redirects trust host-derived input.
+
+Fix:
+
+- Booking and Allrecipes now render relative return paths via
+  `current_relative_url()`.
+- Their post-action redirects validate `next` values with
+  `safe_redirect_target()` and only allow root-relative paths.
+
+### BBC News Share URL
+
+The BBC News article share button copied `window.location.href`, which copies
+the local mirror article URL. The Article rows already carry a `source_url`
+field from the source dataset.
+
+Fix:
+
+- Article detail now passes `article_share_url` to the template.
+- The copy button writes the real `source_url`, or a BBC article fallback URL
+  when no source URL exists.
+
+### GitHub External-Host Recovery
+
+The GitHub mirror has middleware for agents that accidentally request
+`github.com` with this Flask app as the backend. It previously redirected to a
+fixed local mirror URL:
+
+```text
+http://localhost:40006<path>
+```
+
+That is brittle outside the default port layout and leaks a local address when
+the app is mounted under another host or port.
+
+Fix:
+
+- The middleware now redirects to the same relative path on the current host.
+
+## Intentional Matches
+
+These URL-looking values are intentional and should not be "fixed":
+
+- `sites/*/tasks.jsonl`: local mirror entry URLs for benchmark agents.
+- `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `Dockerfile`, and
+  `site_runner.py`: local runtime and container wiring.
+- Form placeholders such as `you@example.com` and editable profile placeholders
+  such as `https://example.com`.
+- GitHub Codespaces terminal copy that says a dev server listens on
+  `http://localhost:3000`.
+- JavaScript that uses `window.location.href` only to update the current page's
+  query string or navigate to a local route.
+
+## Regression Rule
+
+Run this before merging URL-related changes:
+
+```bash
+python3 scripts/check_url_realism.py
+```
+
+The check guards the known user-visible leaks while leaving benchmark/runtime
+localhost contracts intact.

--- a/scripts/check_url_realism.py
+++ b/scripts/check_url_realism.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Regression checks for user-visible URL realism across WebHarbor sites."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CHECKS = [
+    (
+        "Google Map share UI must not expose the local mirror port",
+        ROOT / "sites/google_map/templates/place_detail.html",
+        ["http://localhost:40008", "request.url"],
+    ),
+    (
+        "Google Map seeds must not write example.com place websites",
+        ROOT / "sites/google_map/seed_data.py",
+        [
+            'website=f"https://example.com/{slug}"',
+            'website=f"https://example.com/{syn_slug}"',
+            'kwargs.pop("website", f"https://example.com/{slug}")',
+        ],
+    ),
+    (
+        "BBC article share should not copy the mirror location",
+        ROOT / "sites/bbc_news/templates/article_detail.html",
+        ["navigator.clipboard.writeText(window.location.href)"],
+    ),
+    (
+        "GitHub external-host recovery must not redirect to a fixed local port",
+        ROOT / "sites/github/app.py",
+        ['redirect(f"http://localhost:40006{target}"'],
+    ),
+]
+
+REQUIRED = [
+    (
+        "Google Map runtime URL helpers",
+        ROOT / "sites/google_map/app.py",
+        ["def google_maps_place_url(place):", "def display_place_website(place):"],
+    ),
+    (
+        "BBC real share URL helper",
+        ROOT / "sites/bbc_news/app.py",
+        ["def bbc_article_share_url(article):", "article_share_url=bbc_article_share_url(art)"],
+    ),
+    (
+        "Allrecipes relative next helper",
+        ROOT / "sites/allrecipes/app.py",
+        ["def safe_redirect_target(target", "def current_relative_url():"],
+    ),
+    (
+        "Booking relative next helper",
+        ROOT / "sites/booking/app.py",
+        ["def safe_redirect_target(target", "def current_relative_url():"],
+    ),
+]
+
+RELATIVE_NEXT_TEMPLATES = [
+    ROOT / "sites/allrecipes/templates/recipe_detail.html",
+    ROOT / "sites/booking/templates/index.html",
+    ROOT / "sites/booking/templates/deals.html",
+    ROOT / "sites/booking/templates/stays.html",
+    ROOT / "sites/booking/templates/property_detail.html",
+]
+
+
+def check_forbidden():
+    failed = False
+    for label, path, needles in CHECKS:
+        text = path.read_text()
+        for needle in needles:
+            if needle in text:
+                print(f"{label}: forbidden pattern in {path.relative_to(ROOT)}: {needle}")
+                failed = True
+    return failed
+
+
+def check_required():
+    failed = False
+    for label, path, needles in REQUIRED:
+        text = path.read_text()
+        for needle in needles:
+            if needle not in text:
+                print(f"{label}: missing required pattern in {path.relative_to(ROOT)}: {needle}")
+                failed = True
+    return failed
+
+
+def check_relative_next_templates():
+    failed = False
+    for path in RELATIVE_NEXT_TEMPLATES:
+        text = path.read_text()
+        if 'name="next" value="{{ request.url }}"' in text:
+            print(f"absolute request.url next value in {path.relative_to(ROOT)}")
+            failed = True
+        if 'name="next" value="{{ current_relative_url() }}"' not in text:
+            print(f"missing current_relative_url() next value in {path.relative_to(ROOT)}")
+            failed = True
+    return failed
+
+
+def main():
+    failed = False
+    failed |= check_forbidden()
+    failed |= check_required()
+    failed |= check_relative_next_templates()
+
+    if failed:
+        raise SystemExit(1)
+    print("URL realism checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/sites/allrecipes/app.py
+++ b/sites/allrecipes/app.py
@@ -230,7 +230,21 @@ def utility_processor():
                 user_id=current_user.id, recipe_id=recipe_id).first() is not None
         return False
 
-    return dict(recipe_box_count=recipe_box_count, is_in_recipe_box=is_in_recipe_box)
+    def current_relative_url():
+        path = request.full_path.rstrip('?')
+        return path or url_for('index')
+
+    return dict(
+        recipe_box_count=recipe_box_count,
+        is_in_recipe_box=is_in_recipe_box,
+        current_relative_url=current_relative_url,
+    )
+
+
+def safe_redirect_target(target, default_endpoint='index'):
+    if target and target.startswith('/') and not target.startswith('//'):
+        return target
+    return url_for(default_endpoint)
 
 
 # ---------------------------------------------------------------------------
@@ -1113,7 +1127,7 @@ def login():
             login_user(user, remember=request.form.get('remember'))
             flash('Welcome back!', 'success')
             next_page = request.args.get('next')
-            return redirect(next_page or url_for('index'))
+            return redirect(safe_redirect_target(next_page))
         flash('Invalid email or password.', 'danger')
     return render_template('login.html')
 
@@ -1275,8 +1289,8 @@ def save_to_recipe_box(recipe_id):
         flash(f'"{recipe.title}" saved to your Recipe Box.', 'success')
     else:
         flash(f'"{recipe.title}" is already in your Recipe Box.', 'info')
-    next_page = request.form.get('next') or request.referrer or url_for('recipe_box')
-    return redirect(next_page)
+    next_page = request.form.get('next')
+    return redirect(safe_redirect_target(next_page, 'recipe_box'))
 
 
 @app.route('/recipe-box/note/<int:item_id>', methods=['POST'])

--- a/sites/allrecipes/templates/recipe_detail.html
+++ b/sites/allrecipes/templates/recipe_detail.html
@@ -32,7 +32,7 @@
         {% if not is_in_recipe_box(recipe.id) %}
         <form method="POST" action="{{ url_for('save_to_recipe_box', recipe_id=recipe.id) }}" style="display:inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <input type="hidden" name="next" value="{{ request.url }}">
+            <input type="hidden" name="next" value="{{ current_relative_url() }}">
             <button type="submit" class="recipe-action-btn" style="margin-left:4px">+ Save to Box</button>
         </form>
         {% endif %}

--- a/sites/bbc_news/app.py
+++ b/sites/bbc_news/app.py
@@ -48,6 +48,12 @@ login_manager.login_message = "Please sign in to continue."
 csrf = CSRFProtect(app)
 
 
+def bbc_article_share_url(article):
+    if article.source_url:
+        return article.source_url
+    return f"https://www.bbc.com/news/articles/{article.slug}"
+
+
 # =======================================================================
 # MODELS
 # =======================================================================
@@ -1068,6 +1074,7 @@ def article_detail(slug):
     return render_template(
         "article_detail.html",
         article=art,
+        article_share_url=bbc_article_share_url(art),
         article_gallery=article_gallery,
         related=related,
         more_articles=more_articles,

--- a/sites/bbc_news/templates/article_detail.html
+++ b/sites/bbc_news/templates/article_detail.html
@@ -212,7 +212,7 @@
 {% block extra_js %}
 <script>
 function copyShareUrl() {
-    navigator.clipboard.writeText(window.location.href).then(() => {
+    navigator.clipboard.writeText({{ article_share_url|tojson }}).then(() => {
         alert('Article link copied to clipboard');
     }).catch(() => {});
 }

--- a/sites/booking/app.py
+++ b/sites/booking/app.py
@@ -511,11 +511,23 @@ def inject_global():
         'saved_count': saved_count,
         'current_year': datetime.now().year,
         'csrf_token_value': generate_csrf(),
+        'current_relative_url': current_relative_url,
         'currency_code': currency_code,
         'currency_rate': CURRENCY_RATES[currency_code],
         'currency_symbol': CURRENCY_SYMBOLS[currency_code],
         'currency_rates': CURRENCY_RATES,
     }
+
+
+def current_relative_url():
+    path = request.full_path.rstrip('?')
+    return path or url_for('index')
+
+
+def safe_redirect_target(target, default_endpoint='index'):
+    if target and target.startswith('/') and not target.startswith('//'):
+        return target
+    return url_for(default_endpoint)
 
 
 @app.route('/set-currency', methods=['GET', 'POST'])
@@ -1274,7 +1286,7 @@ def login():
             login_user(user, remember=True)
             flash('Welcome back!', 'success')
             next_url = request.args.get('next')
-            return redirect(next_url or url_for('index'))
+            return redirect(safe_redirect_target(next_url))
         flash('Invalid email or password.', 'danger')
     return render_template('login.html', form=form)
 
@@ -1511,8 +1523,8 @@ def cart_add_form(property_id):
     db.session.add(item)
     db.session.commit()
     flash(f'{prop.name} added to your bag.', 'success')
-    redirect_to = request.form.get('next') or url_for('bag')
-    return redirect(redirect_to)
+    redirect_to = request.form.get('next')
+    return redirect(safe_redirect_target(redirect_to, 'bag'))
 
 
 @app.route('/cart/remove/<int:item_id>', methods=['POST'])
@@ -1573,8 +1585,8 @@ def saved_add_form(property_id):
         flash(f'{prop.name} saved to your wishlist.', 'success')
     else:
         flash(f'{prop.name} is already in your saved list.', 'info')
-    redirect_to = request.form.get('next') or url_for('saved')
-    return redirect(redirect_to)
+    redirect_to = request.form.get('next')
+    return redirect(safe_redirect_target(redirect_to, 'saved'))
 
 
 @app.route('/saved/toggle/<int:property_id>', methods=['POST'])
@@ -1594,7 +1606,7 @@ def saved_toggle_form(property_id):
             db.session.add(SavedProperty(user_id=current_user.id, property_id=property_id))
             db.session.commit()
             flash(f'{prop.name} saved.', 'success')
-    return redirect(request.form.get('next') or url_for('saved'))
+    return redirect(safe_redirect_target(request.form.get('next'), 'saved'))
 
 
 # =====================================================================

--- a/sites/booking/templates/deals.html
+++ b/sites/booking/templates/deals.html
@@ -28,7 +28,7 @@
                 {% if current_user.is_authenticated %}
                 <form method="POST" action="{{ url_for('saved_toggle_form', property_id=prop.id) }}" style="position:absolute;top:8px;right:8px;">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
-                    <input type="hidden" name="next" value="{{ request.url }}">
+                    <input type="hidden" name="next" value="{{ current_relative_url() }}">
                     <button type="submit" class="save-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
                     </button>

--- a/sites/booking/templates/index.html
+++ b/sites/booking/templates/index.html
@@ -139,7 +139,7 @@
                 {% if current_user.is_authenticated %}
                 <form method="POST" action="{{ url_for('saved_toggle_form', property_id=prop.id) }}" style="position:absolute;top:8px;right:8px;">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
-                    <input type="hidden" name="next" value="{{ request.url }}">
+                    <input type="hidden" name="next" value="{{ current_relative_url() }}">
                     <button type="submit" class="save-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
                     </button>

--- a/sites/booking/templates/property_detail.html
+++ b/sites/booking/templates/property_detail.html
@@ -27,7 +27,7 @@
                 {% if current_user.is_authenticated %}
                 <form method="POST" action="{{ url_for('saved_toggle_form', property_id=property.id) }}" style="display:inline;">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
-                    <input type="hidden" name="next" value="{{ request.url }}">
+                    <input type="hidden" name="next" value="{{ current_relative_url() }}">
                     <button type="submit" class="btn-secondary {% if is_saved %}saved{% endif %}" id="saveBtn">
                         {% if is_saved %}&#9829; Saved{% else %}&#9825; Save{% endif %}
                     </button>

--- a/sites/booking/templates/stays.html
+++ b/sites/booking/templates/stays.html
@@ -59,7 +59,7 @@
                 {% if current_user.is_authenticated %}
                 <form method="POST" action="{{ url_for('saved_toggle_form', property_id=prop.id) }}" style="position:absolute;top:8px;right:8px;">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
-                    <input type="hidden" name="next" value="{{ request.url }}">
+                    <input type="hidden" name="next" value="{{ current_relative_url() }}">
                     <button type="submit" class="save-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
                     </button>

--- a/sites/github/app.py
+++ b/sites/github/app.py
@@ -448,7 +448,7 @@ def _redirect_external_github():
     if 'github.com' in host and 'localhost' not in host and '127.0.0.1' not in host:
         target = request.full_path.rstrip('?') or '/'
         # Strip leading /https:/github.com/ or similar, keep the path portion.
-        return redirect(f"http://localhost:40006{target}", code=302)
+        return redirect(target, code=302)
     # Some agents also type URLs like /https://github.com/foo/bar into the bar.
     path = request.path or ''
     m = re.match(r'^/(https?:)?/*github\.com/(.*)$', path)

--- a/sites/google_map/app.py
+++ b/sites/google_map/app.py
@@ -24,6 +24,7 @@ import string
 import secrets
 from datetime import datetime, timedelta
 from pathlib import Path
+from urllib.parse import quote_plus
 
 from flask import (Flask, render_template, request, redirect, url_for,
                    flash, jsonify, abort, session, send_from_directory)
@@ -412,6 +413,20 @@ def ensure_default_lists(user):
     db.session.commit()
 
 
+def google_maps_place_url(place):
+    """Return a real Google Maps place URL for a local mirror Place row."""
+    query = f"{place.name} {place.city.display_name if place.city else ''}".strip()
+    return f"https://www.google.com/maps/place/{quote_plus(query)}/"
+
+
+def display_place_website(place):
+    """Use the stored website unless it is a synthetic placeholder."""
+    website = (place.website or "").strip()
+    if website and "example.com" not in website:
+        return website
+    return google_maps_place_url(place)
+
+
 @app.context_processor
 def inject_globals():
     categories = Category.query.order_by(Category.id).all()
@@ -422,6 +437,8 @@ def inject_globals():
         "global_categories": categories,
         "global_saved_count": saved_count,
         "current_year": datetime.utcnow().year,
+        "display_place_website": display_place_website,
+        "google_maps_place_url": google_maps_place_url,
     }
 
 

--- a/sites/google_map/seed_data.py
+++ b/sites/google_map/seed_data.py
@@ -6,6 +6,7 @@ Enriches each place with address, phone, hours, rating, etc.
 import json
 import random
 from pathlib import Path
+from urllib.parse import quote_plus
 from scrape_wiki import PLACES as RAW_PLACES, CITIES as RAW_CITIES
 
 BASE = Path(__file__).parent
@@ -197,6 +198,12 @@ OPEN_HOURS_TEMPLATES = [
     "Tue–Sat: 11:30 AM – 2:30 PM, 6:00 PM – 10:30 PM",
     "Mon–Fri: 10:00 AM – 5:00 PM, Weekends: 10:00 AM – 6:00 PM",
 ]
+
+
+def google_maps_search_url(name, city_display=""):
+    """Real Google Maps URL for seeded place/share fields."""
+    query = f"{name} {city_display}".strip()
+    return f"https://www.google.com/maps/place/{quote_plus(query)}/"
 
 
 def coord_jitter(base, amount=0.01):
@@ -554,7 +561,7 @@ def build_places(db, Place, Category, City):
             rating=rating,
             review_count=review_count,
             price_level=price,
-            website=f"https://example.com/{slug}",
+            website=google_maps_search_url(name, city.display_name),
             hero_image=hero,
             photos_json=json.dumps(gallery),
             lat=lat,
@@ -628,7 +635,7 @@ def build_places(db, Place, Category, City):
                     rating=round(random.uniform(4.0, 4.8), 1),
                     review_count=random.randint(80, 3500),
                     price_level=price,
-                    website=f"https://example.com/{syn_slug}",
+                    website=google_maps_search_url(name, display),
                     hero_image=hero,
                     photos_json=json.dumps(gallery),
                     lat=lat,
@@ -830,7 +837,7 @@ def seed_task_data(db, Place, Category, City, Route):
             rating=kwargs.pop("rating", 4.5),
             review_count=kwargs.pop("review_count", 500),
             price_level=kwargs.pop("price_level", "$$"),
-            website=kwargs.pop("website", f"https://example.com/{slug}"),
+            website=kwargs.pop("website", google_maps_search_url(name, city.display_name)),
             hero_image=_hero(), photos_json=_gallery(),
             lat=kwargs.pop("lat", city.lat + random.uniform(-0.02, 0.02)),
             lng=kwargs.pop("lng", city.lng + random.uniform(-0.02, 0.02)),

--- a/sites/google_map/templates/place_detail.html
+++ b/sites/google_map/templates/place_detail.html
@@ -81,12 +81,13 @@
         </div>
 
         <div class="share-url" id="share-modal" style="margin:8px 16px 12px; padding:12px 14px; background:#f1f3f4; border:1px solid #dadce0; border-radius:8px; font-size:13px; color:#202124;">
+            {% set share_url = google_maps_place_url(place) %}
             <div style="margin-bottom:6px;"><strong style="font-size:13px;">Share this place</strong></div>
             <div style="color:#5f6368; margin-bottom:6px;">Anyone with this link can view {{ place.name }}:</div>
             <input id="share-url-input" class="share-url-input" type="text" readonly
-                   value="http://localhost:40008{{ url_for('place_detail', slug=place.slug) }}"
+                   value="{{ share_url }}"
                    style="width:100%; padding:8px 10px; border:1px solid #dadce0; border-radius:6px; font-family:monospace; font-size:13px; background:#ffffff;">
-            <div class="share-url-text" style="margin-top:6px; font-family:monospace; font-size:12px; color:#1a73e8; word-break:break-all;">http://localhost:40008{{ url_for('place_detail', slug=place.slug) }}</div>
+            <div class="share-url-text" style="margin-top:6px; font-family:monospace; font-size:12px; color:#1a73e8; word-break:break-all;">{{ share_url }}</div>
         </div>
 
         <div class="pd-block">
@@ -112,7 +113,8 @@
             </div>
             <div class="pd-row">
                 <div class="row-icon"><span class="material-icons-outlined">language</span></div>
-                <div class="row-content"><a href="{{ place.website }}" target="_blank" rel="noopener">{{ place.website|replace('https://', '') }}</a></div>
+                {% set website_url = display_place_website(place) %}
+                <div class="row-content"><a href="{{ website_url }}" target="_blank" rel="noopener">{{ website_url|replace('https://', '') }}</a></div>
             </div>
             {% if place.parking_info %}
             <div class="pd-row">


### PR DESCRIPTION
## Summary

Fixes user-visible URL realism issues across WebHarbor mirror sites while preserving benchmark runtime localhost entry points.

Fixed surfaces:

- Google Map place detail share links no longer expose `http://localhost:40008/place/<slug>`.
- Google Map seeded place websites no longer use `https://example.com/<slug>` placeholders, with runtime fallback for existing packaged DB rows.
- Booking and Allrecipes save/return forms no longer serialize absolute `request.url` mirror URLs into hidden `next` inputs.
- Booking and Allrecipes `next` redirects now only allow root-relative paths.
- BBC News article sharing no longer copies `window.location.href`; it copies the article `source_url` or a BBC fallback URL.
- GitHub external-host recovery no longer redirects to fixed `http://localhost:40006`; it stays on the current host with a relative redirect.
- Adds `docs/url-realism-audit.md` documenting the issue classes, intentional localhost/example.com matches, root causes, and regression rule.
- Replaces the single-site check with `scripts/check_url_realism.py` for the known user-visible URL leak classes.

## Root Cause

The mirrors mixed two URL roles:

1. local benchmark runtime addresses, which are valid in `tasks.jsonl` and docs; and
2. user-visible share/return/external-link surfaces, which should not expose local mirror hosts or placeholder domains.

Several templates and middleware reused local request URLs directly (`request.url`, `window.location.href`, or fixed localhost redirects), causing local mirror addresses to leak into UI or copied links.

## Verification

- `python3 scripts/check_url_realism.py`
- `python3 -m py_compile sites/allrecipes/app.py sites/booking/app.py sites/bbc_news/app.py sites/github/app.py sites/google_map/app.py sites/google_map/seed_data.py scripts/check_url_realism.py`
- Flask test-client checks:
  - Allrecipes authenticated recipe detail renders relative `next` values and rejects absolute next redirects.
  - Booking authenticated home page renders relative `next` values and rejects absolute next redirects.
  - BBC article page writes a real BBC share URL, not `window.location.href` or localhost.
  - GitHub external-host recovery with `Host: github.com` redirects to `/microsoft/vscode?tab=readme`, not `http://localhost:40006/...`.
- Google Map render check from previous pass:
  - `/place/galleria-vittorio-emanuele` renders `https://www.google.com/maps/place/Galleria+Vittorio+Emanuele+II+Milan/` and does not leak `localhost:40008` or `example.com/galleria-vittorio-emanuele`.

Fixes #13.
