### PR TITLE
Align search URLs with upstream sites

### DIFF
--- a/docs/search-url-realism.md
+++ b/docs/search-url-realism.md
@@ -1,0 +1,53 @@
+# Search URL Realism
+
+## Policy
+
+Search forms should emit the URL shape used by the real upstream site whenever
+that shape is known. Legacy `/search?q=...` routes remain as compatibility
+aliases for existing benchmark tasks, hand-written trajectories, and old links.
+
+This keeps the user-visible behavior realistic without breaking existing local
+WebHarbor consumers.
+
+## Canonical Search URLs
+
+| Site | Canonical URL | Legacy alias |
+| --- | --- | --- |
+| Amazon | `/s?k=<query>` | `/search?q=<query>` |
+| Booking | `/searchresults.html?ss=<query>` | `/search?q=<query>` |
+| Google Maps | `/maps/search/<query>` | `/search?q=<query>` |
+| ESPN | `/search/_/q/<query>` | `/search?q=<query>` |
+| Apple | `/search/<query>` | `/search?q=<query>` |
+| Coursera | `/search?query=<query>` | `/search?q=<query>` |
+| Hugging Face | `/search/full-text?q=<query>` | `/search?q=<query>` |
+| Cambridge Dictionary | `/search/direct/?datasetsearch=english&q=<query>` | `/search?q=<query>` |
+| Cambridge Thesaurus | `/search/english-thesaurus/direct/?datasetsearch=english-thesaurus&q=<query>` | `/thesaurus?q=<query>` |
+
+Some sites already matched their upstream search shape closely and are
+documented rather than changed here:
+
+- Google Search: `/search?q=<query>` plus vertical parameters such as `tbm=...`.
+- GitHub: `/search?q=<query>&type=...`.
+- BBC: `/search?q=<query>`.
+- arXiv: `/search/?query=<query>&searchtype=...`.
+- WolframAlpha: `/input?i=<query>` for computation and `/search?q=...` for
+  topic search.
+- Google Flights: primary flight searches already use `/flights?...`; the
+  generic `/search?q=...` page is a local airport/city/airline helper.
+
+HTML forms can only submit query-string values, so path-based canonical search
+URLs use a small submit handler that rewrites the destination before navigation.
+If JavaScript is unavailable, the route still accepts the form-submitted query
+string at the same canonical prefix where possible, and the old alias remains
+available.
+
+## Regression Check
+
+Run:
+
+```bash
+python3 scripts/check_search_url_realism.py
+```
+
+The check verifies that the UI emits canonical search URLs and that the legacy
+aliases remain wired to the same route handlers.

--- a/scripts/check_search_url_realism.py
+++ b/scripts/check_search_url_realism.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Regression checks for realistic search URL shapes."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED = [
+    (
+        "Amazon supports canonical /s?k= search",
+        "sites/amazon/app.py",
+        ["@app.route('/s')", "request.args.get('k')"],
+    ),
+    (
+        "Amazon search UI emits k= on /s",
+        "sites/amazon/templates/base.html",
+        ['action="/s"', 'name="k"'],
+    ),
+    (
+        "Booking supports canonical /searchresults.html?ss=",
+        "sites/booking/app.py",
+        ["@app.route('/searchresults.html')", "request.args.get('ss')"],
+    ),
+    (
+        "Booking search UI emits ss=",
+        "sites/booking/templates/index.html",
+        ['action="/searchresults.html"', 'name="ss"'],
+    ),
+    (
+        "Google Maps supports canonical /maps/search/<query>",
+        "sites/google_map/app.py",
+        ['@app.route("/maps/search/")', '@app.route("/maps/search/<path:maps_query>")'],
+    ),
+    (
+        "Google Maps search UI emits path search",
+        "sites/google_map/templates/_search_bar.html",
+        ['action="/maps/search/"', 'data-path-search="maps"'],
+    ),
+    (
+        "Google Maps path-search submit handler exists",
+        "sites/google_map/static/js/main.js",
+        ['form[data-path-search="maps"]', "'/maps/search/' + encodeURIComponent(query)"],
+    ),
+    (
+        "ESPN supports canonical /search/_/q/<query>",
+        "sites/espn/app.py",
+        ["@app.route('/search/_/q/<path:espn_query>')"],
+    ),
+    (
+        "ESPN search UI emits path search",
+        "sites/espn/templates/search.html",
+        ['action="/search/_/q/"', 'data-path-search="espn"'],
+    ),
+    (
+        "ESPN path-search submit handler exists",
+        "sites/espn/static/js/main.js",
+        ['form[data-path-search="espn"]', "'/search/_/q/' + encodeURIComponent(query)"],
+    ),
+    (
+        "Apple supports canonical /search/<query>",
+        "sites/apple/app.py",
+        ["@app.route('/search/<path:apple_query>')"],
+    ),
+    (
+        "Apple search UI emits path search",
+        "sites/apple/templates/search.html",
+        ['action="/search/"', 'data-path-search="apple"'],
+    ),
+    (
+        "Apple path-search submit handler exists",
+        "sites/apple/static/js/main.js",
+        ['form[data-path-search="apple"]', "'/search/' + encodeURIComponent(query)"],
+    ),
+    (
+        "Coursera supports canonical query= search",
+        "sites/coursera/app.py",
+        ["request.args.get('query')"],
+    ),
+    (
+        "Coursera search UI emits query=",
+        "sites/coursera/templates/base.html",
+        ['action="/search"', 'name="query"'],
+    ),
+    (
+        "Hugging Face supports canonical full-text search",
+        "sites/huggingface/app.py",
+        ['@app.route("/search/full-text")'],
+    ),
+    (
+        "Hugging Face search UI emits full-text path",
+        "sites/huggingface/templates/base.html",
+        ['action="/search/full-text"', 'name="q"'],
+    ),
+    (
+        "Cambridge Dictionary supports direct search path",
+        "sites/cambridge_dictionary/app.py",
+        ["@app.route('/search/direct/')", "@app.route('/search/english/direct/')"],
+    ),
+    (
+        "Cambridge Dictionary search UI emits direct path",
+        "sites/cambridge_dictionary/templates/base.html",
+        [
+            'action="{{ \'/search/english-thesaurus/direct/\' if _is_thes else \'/search/direct/\' }}"',
+            'name="datasetsearch"',
+            "'english-thesaurus' if _is_thes else 'english'",
+        ],
+    ),
+]
+
+FORBIDDEN = [
+    (
+        "Amazon nav should not emit legacy q search",
+        "sites/amazon/templates/base.html",
+        ['action="{{ url_for(\'search\') }}"', 'name="q" placeholder="Search Amazon"'],
+    ),
+    (
+        "Booking homepage should not emit legacy q search",
+        "sites/booking/templates/index.html",
+        ['action="{{ url_for(\'search\') }}"', 'name="q" placeholder="Where are you going?"'],
+    ),
+    (
+        "Coursera nav should not emit legacy q search",
+        "sites/coursera/templates/base.html",
+        ['name="q" placeholder="What do you want to learn?"'],
+    ),
+]
+
+
+def main():
+    failed = False
+    for label, rel, needles in REQUIRED:
+        text = (ROOT / rel).read_text()
+        for needle in needles:
+            if needle not in text:
+                print(f"{label}: missing {needle!r} in {rel}")
+                failed = True
+
+    for label, rel, needles in FORBIDDEN:
+        text = (ROOT / rel).read_text()
+        for needle in needles:
+            if needle in text:
+                print(f"{label}: forbidden {needle!r} in {rel}")
+                failed = True
+
+    if failed:
+        raise SystemExit(1)
+    print("Search URL realism checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/sites/amazon/app.py
+++ b/sites/amazon/app.py
@@ -646,8 +646,9 @@ def _score_product(product, tokens):
 
 
 @app.route('/search')
+@app.route('/s')
 def search():
-    q = request.args.get('q', '').strip()
+    q = (request.args.get('q') or request.args.get('k') or '').strip()
     query_obj = Product.query
     query_obj = _apply_filters(query_obj)  # apply structural filters first
     candidates = query_obj.all()

--- a/sites/amazon/templates/base.html
+++ b/sites/amazon/templates/base.html
@@ -24,7 +24,7 @@
                 </div>
             </a>
 
-            <form class="nav-search nav-search-form" action="{{ url_for('search') }}" method="get">
+            <form class="nav-search nav-search-form" action="/s" method="get">
                 <select class="nav-search-dropdown" name="dept" aria-label="Department">
                     <option>All</option>
                     <option>Electronics</option>
@@ -33,7 +33,7 @@
                     <option>Fashion</option>
                     <option>Beauty</option>
                 </select>
-                <input type="text" class="nav-search-input" name="q" placeholder="Search Amazon" value="{{ request.args.get('q', '') }}" autocomplete="off">
+                <input type="text" class="nav-search-input" name="k" placeholder="Search Amazon" value="{{ request.args.get('k') or request.args.get('q', '') }}" autocomplete="off">
                 <button type="submit" class="nav-search-btn" aria-label="Search">🔍</button>
             </form>
 

--- a/sites/amazon/templates/search.html
+++ b/sites/amazon/templates/search.html
@@ -5,8 +5,8 @@
 {% set qs = request.args %}
 <div class="results-layout">
     <aside class="results-sidebar">
-        <form method="GET" action="{{ url_for('search') }}" id="filter-form">
-            <input type="hidden" name="q" value="{{ query }}">
+        <form method="GET" action="/s" id="filter-form">
+            <input type="hidden" name="k" value="{{ query }}">
             {# Preserve the currently-selected sort across filter-form submits #}
             <input type="hidden" name="sort" value="{{ current_sort or '' }}">
 
@@ -32,7 +32,7 @@
                     </label>
                 </li>
                 {% endfor %}
-                <li><a href="{{ url_for('search', q=query) }}">Clear rating filter</a></li>
+                <li><a href="{{ url_for('search', k=query) }}">Clear rating filter</a></li>
             </ul>
 
             <h3 style="margin-top:20px">Price</h3>
@@ -122,7 +122,7 @@
                 </a>
                 <div>
                     <h2 class="result-card-title"><a href="{{ url_for('product_detail', slug=p.slug) }}">{{ p.name }}</a></h2>
-                    <div class="result-card-brand">by <a href="{{ url_for('search', q=p.brand) }}">{{ p.brand }}</a></div>
+                    <div class="result-card-brand">by <a href="{{ url_for('search', k=p.brand) }}">{{ p.brand }}</a></div>
                     <div class="result-card-rating rating">
                         <span class="stars">{% for i in range(p.rating|int) %}★{% endfor %}{% for i in range(5 - p.rating|int) %}☆{% endfor %}</span>
                         <span>{{ p.rating }} ({{ '{:,}'.format(p.review_count) }})</span>

--- a/sites/apple/app.py
+++ b/sites/apple/app.py
@@ -1259,8 +1259,9 @@ def _apply_sort(results, key):
 
 
 @app.route('/search')
-def search():
-    q = request.args.get('q', '').strip()
+@app.route('/search/<path:apple_query>')
+def search(apple_query=''):
+    q = (apple_query or request.args.get('q', '')).strip()
     query_obj = Product.query
     query_obj = _apply_product_filters(query_obj)
     candidates = query_obj.all()

--- a/sites/apple/static/js/main.js
+++ b/sites/apple/static/js/main.js
@@ -5,8 +5,24 @@
 document.addEventListener('DOMContentLoaded', () => {
     initNavbar();
     initFlashMessages();
+    initPathSearchForms();
     initScrollAnimations();
 });
+
+function initPathSearchForms() {
+    document.querySelectorAll('form[data-path-search="apple"]').forEach(form => {
+        form.addEventListener('submit', event => {
+            const input = form.querySelector('input[name="q"]');
+            const query = input ? input.value.trim() : '';
+            if (!query) return;
+            event.preventDefault();
+            const params = new URLSearchParams(new FormData(form));
+            params.delete('q');
+            const suffix = params.toString();
+            window.location.href = '/search/' + encodeURIComponent(query) + (suffix ? '?' + suffix : '');
+        });
+    });
+}
 
 /* --- Navbar scroll effect --- */
 function initNavbar() {

--- a/sites/apple/templates/search.html
+++ b/sites/apple/templates/search.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="search-page">
     <div class="search-input-wrapper">
-        <form action="{{ url_for('search') }}" method="GET">
+        <form action="/search/" method="GET" data-path-search="apple">
             <input type="text" name="q" class="search-input" value="{{ query }}"
                    placeholder="Search apple.com" autofocus>
         </form>

--- a/sites/booking/app.py
+++ b/sites/booking/app.py
@@ -940,8 +940,9 @@ def _is_beach_relevant_city(city):
 
 
 @app.route('/search')
+@app.route('/searchresults.html')
 def search():
-    q = (request.args.get('q') or '').strip()
+    q = (request.args.get('q') or request.args.get('ss') or '').strip()
     dest = (request.args.get('dest') or request.args.get('destination') or '').strip()
     near = (request.args.get('near') or '').strip()
     city_id = request.args.get('city_id', type=int)

--- a/sites/booking/templates/airport_taxis.html
+++ b/sites/booking/templates/airport_taxis.html
@@ -6,9 +6,9 @@
         <h1>Airport taxis — easy door-to-door transfers</h1>
         <p>Pre-book your ride to your destination for a stress-free start.</p>
     </div>
-    <form class="search-bar" action="{{ url_for('search') }}" method="get">
+    <form class="search-bar" action="/searchresults.html" method="get">
         <div class="search-field">
-            <input type="text" name="q" placeholder="Airport">
+            <input type="text" name="ss" placeholder="Airport">
         </div>
         <div class="search-field">
             <input type="text" placeholder="Hotel or address">

--- a/sites/booking/templates/attractions.html
+++ b/sites/booking/templates/attractions.html
@@ -6,10 +6,10 @@
         <h1>Attractions, tours & experiences</h1>
         <p>Discover incredible things to do around the world — skip the lines.</p>
     </div>
-    <form class="search-bar" action="{{ url_for('search') }}" method="get">
+    <form class="search-bar" action="/searchresults.html" method="get">
         <div class="search-field">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/></svg>
-            <input type="text" name="q" placeholder="Where do you want to go?">
+            <input type="text" name="ss" placeholder="Where do you want to go?">
         </div>
         <div class="search-field">
             <input type="text" maxlength="10" inputmode="numeric" pattern="\d{4}-\d{2}-\d{2}" placeholder="YYYY-MM-DD" autocomplete="off" data-datepicker="single">

--- a/sites/booking/templates/car_rentals.html
+++ b/sites/booking/templates/car_rentals.html
@@ -6,10 +6,10 @@
         <h1>Car rentals for any kind of trip</h1>
         <p>Great deals at over 60,000 locations worldwide.</p>
     </div>
-    <form class="search-bar" action="{{ url_for('search') }}" method="get">
+    <form class="search-bar" action="/searchresults.html" method="get">
         <div class="search-field">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg>
-            <input type="text" name="q" placeholder="Pick-up location">
+            <input type="text" name="ss" placeholder="Pick-up location">
         </div>
         <div class="search-field">
             <input type="text" maxlength="10" inputmode="numeric" pattern="\d{4}-\d{2}-\d{2}" placeholder="Pick-up (YYYY-MM-DD)" autocomplete="off" data-datepicker="checkin">

--- a/sites/booking/templates/flights.html
+++ b/sites/booking/templates/flights.html
@@ -6,10 +6,10 @@
         <h1>Book cheap flights</h1>
         <p>Find low fares to top destinations on our official site.</p>
     </div>
-    <form class="search-bar" action="{{ url_for('search') }}" method="get">
+    <form class="search-bar" action="/searchresults.html" method="get">
         <div class="search-field">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12l20-8-8 20-2-9-10-3z"/></svg>
-            <input type="text" name="q" placeholder="From">
+            <input type="text" name="ss" placeholder="From">
         </div>
         <div class="search-field">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12l20-8-8 20-2-9-10-3z" transform="rotate(90 12 12)"/></svg>

--- a/sites/booking/templates/index.html
+++ b/sites/booking/templates/index.html
@@ -6,10 +6,10 @@
         <h1>Find your next stay</h1>
         <p>Search low prices on hotels, homes and much more...</p>
     </div>
-    <form class="search-bar" action="{{ url_for('search') }}" method="get">
+    <form class="search-bar" action="/searchresults.html" method="get">
         <div class="search-field">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
-            <input type="text" name="q" placeholder="Where are you going?" autocomplete="off" required minlength="2">
+            <input type="text" name="ss" placeholder="Where are you going?" autocomplete="off" required minlength="2">
         </div>
         <div class="search-field">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>

--- a/sites/booking/templates/search.html
+++ b/sites/booking/templates/search.html
@@ -26,7 +26,7 @@
     <form method="get" id="searchForm" style="background:#fff;padding:16px;border-radius:8px;border:1px solid #e7e7e7;margin-bottom:20px;display:flex;gap:12px;flex-wrap:wrap;align-items:end;">
         <div class="form-group" style="margin:0;flex:1;min-width:200px;">
             <label>Keyword / destination</label>
-            <input type="text" name="q" value="{{ query }}" placeholder="Property, city or landmark" required minlength="2">
+            <input type="text" name="ss" value="{{ query }}" placeholder="Property, city or landmark" required minlength="2">
         </div>
         <div class="form-group" style="margin:0;flex:1;min-width:160px;">
             <label>City</label>
@@ -66,7 +66,7 @@
         <aside class="filter-sidebar" style="background:#fff;border:1px solid #e7e7e7;border-radius:8px;padding:16px;position:sticky;top:12px;">
             <form method="get" id="filterForm">
                 {# carry over keyword + city + occupancy #}
-                {% if query %}<input type="hidden" name="q" value="{{ query }}">{% endif %}
+                {% if query %}<input type="hidden" name="ss" value="{{ query }}">{% endif %}
                 {% if args.get('city_id') %}<input type="hidden" name="city_id" value="{{ args.get('city_id') }}">{% endif %}
                 {% if args.get('city') %}<input type="hidden" name="city" value="{{ args.get('city') }}">{% endif %}
                 {% if args.get('dest') %}<input type="hidden" name="dest" value="{{ args.get('dest') }}">{% endif %}

--- a/sites/cambridge_dictionary/app.py
+++ b/sites/cambridge_dictionary/app.py
@@ -402,6 +402,8 @@ def word_detail(slug):
 
 
 @app.route('/search')
+@app.route('/search/direct/')
+@app.route('/search/english/direct/')
 def search():
     q = request.args.get('q', '').strip()
     search_type = request.args.get('type', 'dictionary')
@@ -511,6 +513,7 @@ def thesaurus_article(slug):
 
 
 @app.route('/thesaurus')
+@app.route('/search/english-thesaurus/direct/')
 def thesaurus_search():
     q = request.args.get('q', '').strip()
     if not q:

--- a/sites/cambridge_dictionary/templates/base.html
+++ b/sites/cambridge_dictionary/templates/base.html
@@ -64,7 +64,7 @@
         </span>
       </a>
       {% set _is_thes = 'thesaurus' in (request.endpoint or '') %}
-      <form action="{{ url_for('thesaurus_search') if _is_thes else url_for('search') }}" method="GET" class="search-form" autocomplete="off">
+      <form action="{{ '/search/english-thesaurus/direct/' if _is_thes else '/search/direct/' }}" method="GET" class="search-form" autocomplete="off">
         <div class="search-tabs">
           <a href="{{ url_for('index') }}" class="stab {% if request.endpoint in ['index','word_detail','search'] %}active{% endif %}">Dictionary</a>
           <a href="{{ url_for('thesaurus_search') }}" class="stab {% if 'thesaurus' in (request.endpoint or '') %}active{% endif %}">Thesaurus</a>
@@ -72,6 +72,7 @@
           <a href="{{ url_for('grammar_index') }}" class="stab {% if 'grammar' in (request.endpoint or '') %}active{% endif %}">Grammar</a>
         </div>
         <div class="search-input-wrap">
+          <input type="hidden" name="datasetsearch" value="{{ 'english-thesaurus' if _is_thes else 'english' }}">
           <input type="text" name="q" id="searchInput" class="search-input"
                  placeholder="{{ ui.search_placeholder }}"
                  value="{{ request.args.get('q','') }}">

--- a/sites/cambridge_dictionary/templates/thesaurus_index.html
+++ b/sites/cambridge_dictionary/templates/thesaurus_index.html
@@ -5,8 +5,9 @@
   <h1 class="page-title">Cambridge Thesaurus</h1>
   <p class="page-desc">Find synonyms and related words for any English word or phrase.</p>
 
-  <form action="{{ url_for('thesaurus_search') }}" method="GET" class="thes-search-form">
+  <form action="/search/english-thesaurus/direct/" method="GET" class="thes-search-form">
     <div class="search-input-wrap big">
+      <input type="hidden" name="datasetsearch" value="english-thesaurus">
       <input type="text" name="q" placeholder="Search for a word or phrase…"
              value="{{ q }}" class="search-input big">
       <button type="submit" class="search-btn">Search</button>

--- a/sites/coursera/app.py
+++ b/sites/coursera/app.py
@@ -835,7 +835,7 @@ def browse(category_slug):
 
 @app.route('/search')
 def search():
-    q = request.args.get('q', '').strip()
+    q = (request.args.get('q') or request.args.get('query') or '').strip()
     level = request.args.get('level', '')
     course_type = request.args.get('type', '')
     duration = request.args.get('duration', '')

--- a/sites/coursera/templates/base.html
+++ b/sites/coursera/templates/base.html
@@ -38,7 +38,7 @@
               <h4>Goals</h4>
               <a href="{{ url_for('degrees') }}">Take a degree</a>
               <a href="{{ url_for('professional_certificates') }}">Earn a Certificate</a>
-              <a href="{{ url_for('search') }}?free=1">Learn for Free</a>
+              <a href="/search?free=1">Learn for Free</a>
               <a href="{{ url_for('coursera_plus') }}">Coursera Plus</a>
             </div>
             <div class="dropdown-col">
@@ -57,8 +57,8 @@
         </div>
       </div>
     </div>
-    <form class="nav-search" action="{{ url_for('search') }}" method="get" role="search">
-      <input type="text" name="q" placeholder="What do you want to learn?" value="{{ request.args.get('q', '') }}" aria-label="Search">
+    <form class="nav-search" action="/search" method="get" role="search">
+      <input type="text" name="query" placeholder="What do you want to learn?" value="{{ request.args.get('query') or request.args.get('q', '') }}" aria-label="Search">
       <button type="submit" aria-label="Search">&#128269;</button>
     </form>
     <div class="nav-auth">
@@ -79,12 +79,12 @@
   <div class="footer-inner">
     <div class="footer-col">
       <h4>Skills</h4>
-      <a href="{{ url_for('search') }}?q=python">Python Skills</a>
-      <a href="{{ url_for('search') }}?q=excel">Excel Skills</a>
-      <a href="{{ url_for('search') }}?q=data+analysis">Data Analysis</a>
-      <a href="{{ url_for('search') }}?q=machine+learning">Machine Learning</a>
-      <a href="{{ url_for('search') }}?q=cybersecurity">Cybersecurity</a>
-      <a href="{{ url_for('search') }}?q=project+management">Project Management</a>
+      <a href="{{ url_for('search') }}?query=python">Python Skills</a>
+      <a href="{{ url_for('search') }}?query=excel">Excel Skills</a>
+      <a href="{{ url_for('search') }}?query=data+analysis">Data Analysis</a>
+      <a href="{{ url_for('search') }}?query=machine+learning">Machine Learning</a>
+      <a href="{{ url_for('search') }}?query=cybersecurity">Cybersecurity</a>
+      <a href="{{ url_for('search') }}?query=project+management">Project Management</a>
     </div>
     <div class="footer-col">
       <h4>Professional Certificates</h4>
@@ -92,14 +92,14 @@
       <a href="{{ url_for('professional_certificates') }}">IBM Certificates</a>
       <a href="{{ url_for('professional_certificates') }}">Meta Certificates</a>
       <a href="{{ url_for('professional_certificates') }}">All Certificates</a>
-      <a href="{{ url_for('search') }}?type=Professional+Certificate">Browse Certificates</a>
+      <a href="/search?type=Professional+Certificate">Browse Certificates</a>
     </div>
     <div class="footer-col">
       <h4>Courses &amp; Specializations</h4>
-      <a href="{{ url_for('search') }}?type=Course">Courses</a>
-      <a href="{{ url_for('search') }}?type=Specialization">Specializations</a>
-      <a href="{{ url_for('search') }}?type=Guided+Project">Guided Projects</a>
-      <a href="{{ url_for('search') }}?free=1">Free Courses</a>
+      <a href="/search?type=Course">Courses</a>
+      <a href="/search?type=Specialization">Specializations</a>
+      <a href="/search?type=Guided+Project">Guided Projects</a>
+      <a href="/search?free=1">Free Courses</a>
       <a href="{{ url_for('coursera_plus') }}">Coursera Plus</a>
       <a href="{{ url_for('degrees') }}">Online Degrees</a>
     </div>

--- a/sites/coursera/templates/search.html
+++ b/sites/coursera/templates/search.html
@@ -10,8 +10,8 @@
     {% if free == '1' or credit == '1' or certificate == '1' or min_rating %}{% set active_count = active_count + 1 %}{% endif %}
     {% if sort and sort != 'popular' %}{% set active_count = active_count + 1 %}{% endif %}
 
-    <form id="filter-form" action="{{ url_for('search') }}" method="get" class="filter-pill-row">
-      <input type="hidden" name="q" value="{{ q }}">
+    <form id="filter-form" action="/search" method="get" class="filter-pill-row">
+      <input type="hidden" name="query" value="{{ q }}">
 
       {# ---- Filter & Sort master pill ---- #}
       <details class="filter-pill filter-pill-master {% if active_count %}filter-pill-active{% endif %}">
@@ -63,7 +63,7 @@
           </div>
 
           <div class="fp-footer">
-            <a href="{{ url_for('search') }}?q={{ q }}" class="fp-clear">Clear all</a>
+            <a href="/search?query={{ q|urlencode }}" class="fp-clear">Clear all</a>
             <button type="submit" class="btn-primary fp-view">View</button>
           </div>
         </div>
@@ -81,7 +81,7 @@
           </label>
           {% endfor %}
           <div class="fp-footer">
-            <a href="{{ url_for('search') }}?q={{ q }}&amp;sort={{ sort }}" class="fp-clear">Clear</a>
+            <a href="/search?query={{ q|urlencode }}&amp;sort={{ sort }}" class="fp-clear">Clear</a>
             <button type="submit" class="btn-primary fp-view">View</button>
           </div>
         </div>
@@ -100,7 +100,7 @@
           </label>
           {% endfor %}
           <div class="fp-footer">
-            <a href="{{ url_for('search') }}?q={{ q }}" class="fp-clear">Clear</a>
+            <a href="/search?query={{ q|urlencode }}" class="fp-clear">Clear</a>
             <button type="submit" class="btn-primary fp-view">View</button>
           </div>
         </div>
@@ -118,7 +118,7 @@
           </label>
           {% endfor %}
           <div class="fp-footer">
-            <a href="{{ url_for('search') }}?q={{ q }}" class="fp-clear">Clear</a>
+            <a href="/search?query={{ q|urlencode }}" class="fp-clear">Clear</a>
             <button type="submit" class="btn-primary fp-view">View</button>
           </div>
         </div>
@@ -134,7 +134,7 @@
             English
           </label>
           <div class="fp-footer">
-            <a href="{{ url_for('search') }}?q={{ q }}" class="fp-clear">Clear</a>
+            <a href="/search?query={{ q|urlencode }}" class="fp-clear">Clear</a>
             <button type="submit" class="btn-primary fp-view">View</button>
           </div>
         </div>
@@ -152,7 +152,7 @@
           </label>
           {% endfor %}
           <div class="fp-footer">
-            <a href="{{ url_for('search') }}?q={{ q }}" class="fp-clear">Clear</a>
+            <a href="/search?query={{ q|urlencode }}" class="fp-clear">Clear</a>
             <button type="submit" class="btn-primary fp-view">View</button>
           </div>
         </div>

--- a/sites/espn/app.py
+++ b/sites/espn/app.py
@@ -965,8 +965,9 @@ def article(slug):
 # ─── Routes: Search ───────────────────────────────────────────────────────────
 
 @app.route('/search')
-def search():
-    q = request.args.get('q', '').strip()
+@app.route('/search/_/q/<path:espn_query>')
+def search(espn_query=''):
+    q = (espn_query or request.args.get('q', '')).strip()
     sport_filter = request.args.get('sport', '')
     type_filter = request.args.get('type', '')  # teams, players, articles
 

--- a/sites/espn/static/js/main.js
+++ b/sites/espn/static/js/main.js
@@ -1,6 +1,19 @@
 /* ESPN Mirror - Main JavaScript */
 
 document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('form[data-path-search="espn"]').forEach(function (form) {
+        form.addEventListener('submit', function (event) {
+            const input = form.querySelector('input[name="q"]');
+            const query = input ? input.value.trim() : '';
+            if (!query) return;
+            event.preventDefault();
+            const params = new URLSearchParams(new FormData(form));
+            params.delete('q');
+            const suffix = params.toString();
+            window.location.href = '/search/_/q/' + encodeURIComponent(query) + (suffix ? '?' + suffix : '');
+        });
+    });
+
     // Mobile navigation toggle
     const menuToggle = document.querySelector('.mobile-menu-toggle');
     const navLinks = document.querySelector('.nav-links');

--- a/sites/espn/templates/search.html
+++ b/sites/espn/templates/search.html
@@ -7,7 +7,7 @@
     <h1>Search ESPN</h1>
 
     <!-- Search Form -->
-    <form method="get" action="/search" class="search-form">
+    <form method="get" action="/search/_/q/" class="search-form" data-path-search="espn">
       <div class="search-bar">
         <input type="text" name="q" value="{{ query }}" placeholder="Search teams, players, news..." class="search-input" autofocus>
         <button type="submit" class="btn-red search-submit">Search</button>

--- a/sites/google_map/app.py
+++ b/sites/google_map/app.py
@@ -1016,8 +1016,10 @@ def _apply_place_sort(results, sort):
 
 
 @app.route("/search")
-def search():
-    q = request.args.get("q", "").strip()
+@app.route("/maps/search/")
+@app.route("/maps/search/<path:maps_query>")
+def search(maps_query=""):
+    q = (maps_query or request.args.get("q", "")).strip()
     sort = request.args.get("sort", "")
     args = request.args
 

--- a/sites/google_map/static/js/main.js
+++ b/sites/google_map/static/js/main.js
@@ -21,6 +21,19 @@
         });
     });
 
+    document.querySelectorAll('form[data-path-search="maps"]').forEach(function (form) {
+        form.addEventListener('submit', function (event) {
+            var input = form.querySelector('input[name="q"]');
+            var query = input ? input.value.trim() : '';
+            if (!query) return;
+            event.preventDefault();
+            var params = new URLSearchParams(new FormData(form));
+            params.delete('q');
+            var suffix = params.toString();
+            window.location.href = '/maps/search/' + encodeURIComponent(query) + (suffix ? '?' + suffix : '');
+        });
+    });
+
     // Save place toggle
     window.toggleSave = function (placeId, btn) {
         fetch('/api/save', {

--- a/sites/google_map/templates/_search_bar.html
+++ b/sites/google_map/templates/_search_bar.html
@@ -1,5 +1,5 @@
 <div class="search-bar-row">
-    <form class="search-bar" method="GET" action="{{ url_for('search') }}">
+    <form class="search-bar" method="GET" action="/maps/search/" data-path-search="maps">
         <button type="button" class="icon-btn" title="Menu"><span class="material-icons-outlined">menu</span></button>
         <input type="text" name="q" placeholder="Search Google Maps" value="{{ search_value|default('') }}">
         <button type="submit" class="icon-btn" title="Search"><span class="material-icons-outlined">search</span></button>

--- a/sites/google_map/templates/search.html
+++ b/sites/google_map/templates/search.html
@@ -26,7 +26,7 @@
         {% set f_price = request.args.get('price_level', '') %}
         {% set f_active = f_hours or f_rating or f_price %}
         <div class="filter-chips">
-            <form method="GET" action="/search" class="chip-form">
+            <form method="GET" action="/maps/search/" class="chip-form" data-path-search="maps">
                 <input type="hidden" name="q" value="{{ q }}">
                 {% if request.args.get('sort') %}<input type="hidden" name="sort" value="{{ request.args.get('sort') }}">{% endif %}
 

--- a/sites/huggingface/app.py
+++ b/sites/huggingface/app.py
@@ -2326,6 +2326,7 @@ def discussion_upvote(discussion_id):
 # Search
 # ------------------------------------------------------------
 @app.route("/search")
+@app.route("/search/full-text")
 def search():
     q_raw = request.args.get("q", "").strip()
     kind = request.args.get("type", "all")

--- a/sites/huggingface/templates/base.html
+++ b/sites/huggingface/templates/base.html
@@ -15,7 +15,7 @@
             <span class="gn-logo-emoji">🤗</span>
             <span>Hugging Face</span>
         </a>
-        <form class="gn-search" action="{{ url_for('search') }}" method="get">
+        <form class="gn-search" action="/search/full-text" method="get">
             <input type="text" name="q" placeholder="Search models, datasets, users..." value="{{ request.args.get('q', '') }}">
         </form>
         <div class="gn-nav">

--- a/sites/huggingface/templates/search.html
+++ b/sites/huggingface/templates/search.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="container-wide page">
-    <form class="search-form" action="{{ url_for('search') }}" method="get">
+    <form class="search-form" action="/search/full-text" method="get">
         <input type="text" name="q" class="form-control form-control-lg" placeholder="Search models, datasets, spaces…" value="{{ q }}" autofocus>
         <input type="hidden" name="type" value="{{ kind }}">
         <input type="hidden" name="sort" value="{{ active_sort }}">


### PR DESCRIPTION
## Summary

Makes known search URL shapes realistic while keeping old `/search?q=...` routes as compatibility aliases.

Canonical search URLs added/emitted:

- Amazon: `/s?k=<query>` with `/search?q=<query>` kept as legacy alias.
- Booking: `/searchresults.html?ss=<query>` with `/search?q=<query>` kept as legacy alias.
- Google Maps: `/maps/search/<query>` with `/search?q=<query>` kept as legacy alias.
- ESPN: `/search/_/q/<query>` with `/search?q=<query>` kept as legacy alias.
- Apple: `/search/<query>` with `/search?q=<query>` kept as legacy alias.
- Coursera: `/search?query=<query>` with `/search?q=<query>` kept as legacy alias.
- Hugging Face: `/search/full-text?q=<query>` with `/search?q=<query>` kept as legacy alias.
- Cambridge Dictionary: `/search/direct/?datasetsearch=english&q=<query>` with `/search?q=<query>` kept as legacy alias.
- Cambridge Thesaurus: `/search/english-thesaurus/direct/?datasetsearch=english-thesaurus&q=<query>` with `/thesaurus?q=<query>` kept as legacy alias.

Audited and documented as already close to upstream shape or intentionally different:

- Google Search: `/search?q=<query>` plus vertical params such as `tbm=...`.
- GitHub: `/search?q=<query>&type=...`.
- BBC: `/search?q=<query>`.
- arXiv: `/search/?query=<query>&searchtype=...`.
- WolframAlpha: `/input?i=<query>` for computation and `/search?q=...` for topic search.
- Google Flights: primary flight searches already use `/flights?...`; generic `/search?q=...` is a local airport/city/airline helper.

For path-based search URLs, small submit handlers rewrite the destination before navigation so the browser location becomes the upstream-shaped URL. Existing no-JS/query-string aliases still resolve through the same search view.

Also adds:

- `docs/search-url-realism.md`
- `scripts/check_search_url_realism.py`

## Verification

- `python3 scripts/check_search_url_realism.py`
- `python3 -m py_compile sites/amazon/app.py sites/booking/app.py sites/google_map/app.py sites/espn/app.py sites/apple/app.py sites/coursera/app.py sites/huggingface/app.py sites/cambridge_dictionary/app.py scripts/check_search_url_realism.py`
- Flask test-client route checks for canonical and legacy URLs:
  - Amazon `/s?k=xbox` and `/search?q=xbox`
  - Booking `/searchresults.html?ss=Paris` and `/search?q=Paris`
  - Google Maps `/maps/search/central%20park` and `/search?q=central%20park`
  - ESPN `/search/_/q/lakers` and `/search?q=lakers`
  - Apple `/search/iphone` and `/search?q=iphone`
  - Coursera `/search?query=python` and `/search?q=python`
  - Cambridge `/search/direct/?datasetsearch=english&q=hello` and `/search?q=hello`
- Hugging Face full route was covered by static regression and `py_compile`; full render smoke requires HF-managed image assets that are not present in this isolated worktree.

Fixes #14.
