### PR TITLE
Normalize duplicated arXiv LaTeX metadata

### DIFF
--- a/scripts/check_arxiv_metadata_latex.py
+++ b/scripts/check_arxiv_metadata_latex.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Regression checks for arXiv metadata LaTeX cleanup."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARXIV_DIR = ROOT / "sites/arxiv"
+PAPERS = ARXIV_DIR / "papers.json"
+
+
+def main():
+    sys.path.insert(0, str(ARXIV_DIR))
+    from metadata_cleaning import clean_arxiv_metadata_text as clean
+    from metadata_cleaning import format_arxiv_display_text as display
+    papers = json.loads(PAPERS.read_text())
+    by_id = {paper.get("arxiv_id"): paper for paper in papers}
+
+    known_cases = {
+        "2604.07983": {
+            "contains": [r"$\gtrsim 100\times$", r"$z=1.37$", "SN 2025mkn"],
+            "forbidden": [r"\gtrsim 100\times\gtrsim 100\times", "z=1.37z=1.37"],
+        },
+        "2604.04709": {
+            "contains": [r"\mathbb{P}^1"],
+            "forbidden": [r"\mathbb{P}^1\mathbb{P}^1"],
+        },
+        "2604.07446": {
+            "contains": [r"\mathcal{N}=1"],
+            "forbidden": [r"\mathcal{N}=1\mathcal{N}=1", "CFT_3_3"],
+        },
+        "2206.03566": {
+            "contains": [r"\mathbb{R}^4"],
+            "forbidden": [r"\mathbb{R}^4\mathbb{R}^4"],
+        },
+        "2511.23096": {
+            "contains": [r"GL(d_1)\times GL(d_2)"],
+            "forbidden": [r"GL(d_1)\times GL(d_2)GL(d_1)\times GL(d_2)"],
+        },
+    }
+
+    for arxiv_id, checks in known_cases.items():
+        paper = by_id.get(arxiv_id)
+        if not paper:
+            raise SystemExit(f"missing arXiv fixture {arxiv_id}")
+        cleaned_title = clean(paper.get("title", ""))
+        for text in checks["contains"]:
+            if text not in cleaned_title:
+                raise SystemExit(f"{arxiv_id}: expected cleaned title fragment missing: {text}")
+        for text in checks["forbidden"]:
+            if text in cleaned_title:
+                raise SystemExit(f"{arxiv_id}: duplicated title fragment remains: {text}")
+
+    display_cases = {
+        r"A Natural $\gtrsim 100\times$ Telescope at $z=1.37$": [
+            "≥ 100×",
+            "z=1.37",
+        ],
+        r"Project page \url{this https URL}": [
+            "Project page this https URL",
+        ],
+        r"available at \href{this https URL}{GitHub}": [
+            "available at GitHub",
+        ],
+        r"$\mathbb{R}^4$ and $\mathcal{N}=2$": [
+            "R^4",
+            "N=2",
+        ],
+    }
+    for raw, fragments in display_cases.items():
+        rendered = display(raw)
+        for fragment in fragments:
+            if fragment not in rendered:
+                raise SystemExit(f"display fragment missing: {fragment!r} from {rendered!r}")
+        if "\\" in rendered or "$" in rendered:
+            raise SystemExit(f"display still contains raw TeX delimiters: {rendered!r}")
+
+    duplicate_patterns = [
+        re.compile(r"(\\mathbb\{[^}]+\}\^?[^\\\s]*)\1"),
+        re.compile(r"(\\mathcal\{[^}]+\}=?[0-9A-Za-z]*)\1"),
+        re.compile(r"(\\mathrm\{[^}]+\}[_^]?\{?[^{}\s]*\}?)\1"),
+        re.compile(r"\b(z=[0-9.]+)\1\b"),
+        re.compile(r"(\$[^$]{1,120}\$)\s*\1"),
+        re.compile(r"(GL\(d_1\)\\times GL\(d_2\))\1"),
+    ]
+    failures = []
+    for paper in papers:
+        cleaned_title = clean(paper.get("title", ""))
+        for pattern in duplicate_patterns:
+            if pattern.search(cleaned_title):
+                failures.append((paper.get("arxiv_id"), cleaned_title))
+                break
+    if failures:
+        preview = "\n".join(f"{pid}: {title}" for pid, title in failures[:20])
+        raise SystemExit(f"duplicated LaTeX fragments remain in cleaned titles:\n{preview}")
+
+    display_failures = []
+    for paper in papers:
+        for field in ("title", "abstract", "comments"):
+            rendered = display(paper.get(field, ""))
+            if r"\href{" in rendered or r"\url{" in rendered:
+                display_failures.append((paper.get("arxiv_id"), field, rendered[:160]))
+    if display_failures:
+        preview = "\n".join(f"{pid} {field}: {text}" for pid, field, text in display_failures[:20])
+        raise SystemExit(f"raw URL TeX commands remain in display text:\n{preview}")
+
+    print("arXiv metadata LaTeX checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/sites/arxiv/app.py
+++ b/sites/arxiv/app.py
@@ -29,6 +29,8 @@ from flask_bcrypt import Bcrypt
 from flask_wtf import CSRFProtect
 from sqlalchemy import or_, and_, func
 
+from metadata_cleaning import clean_arxiv_metadata_text, format_arxiv_display_text
+
 BASE_DIR = Path(__file__).parent
 DB_DIR = BASE_DIR / "instance"
 DB_DIR.mkdir(exist_ok=True)
@@ -197,11 +199,28 @@ class Paper(db.Model):
 
     @property
     def short_abstract(self):
-        if not self.abstract:
+        abstract = self.display_abstract
+        if not abstract:
             return "Abstract not available."
-        if len(self.abstract) > 280:
-            return self.abstract[:280] + "…"
-        return self.abstract
+        if len(abstract) > 280:
+            return abstract[:280] + "…"
+        return abstract
+
+    @property
+    def display_title(self):
+        return format_arxiv_display_text(self.title or "")
+
+    @property
+    def display_abstract(self):
+        return format_arxiv_display_text(self.abstract or "")
+
+    @property
+    def display_comments(self):
+        return format_arxiv_display_text(self.comments or "")
+
+    @property
+    def display_journal_ref(self):
+        return format_arxiv_display_text(self.journal_ref or "")
 
     @property
     def subject_list(self):
@@ -443,6 +462,10 @@ def _synthesize_abstract(title: str, subject_code: str,
             f"experiments.")
 
 
+def _clean_arxiv_metadata_text(text):
+    return clean_arxiv_metadata_text(text)
+
+
 def seed_database():
     """Populate the DB from categories.json + papers.json."""
     if Category.query.first() is not None:
@@ -521,7 +544,7 @@ def seed_database():
         if primary_category not in primary_cats and subject_code in primary_cats:
             primary_category = subject_code
         # Titles
-        title = rp.get("title", "").strip()
+        title = _clean_arxiv_metadata_text(rp.get("title", "").strip())
         if not title:
             continue
         # Parse date, falling back to arxiv-id-encoded yymm (e.g. 2604.08525 -> 2026-04)
@@ -547,7 +570,7 @@ def seed_database():
         if not authors:
             authors = _synthesize_authors(arxiv_id)
         # Parse figures, tables, formulas counts from comments
-        cmt = rp.get("comments", "")
+        cmt = _clean_arxiv_metadata_text(rp.get("comments", ""))
         figs = 0
         tbls = 0
         frms = 0
@@ -564,7 +587,7 @@ def seed_database():
         versions = rp.get("versions", [])
         # Loss function from abstract
         loss_fn = ""
-        abs_text = rp.get("abstract", "") or ""
+        abs_text = _clean_arxiv_metadata_text(rp.get("abstract", "") or "")
         # Backfill empty abstracts for high-traffic categories so the /abs
         # and listing pages always surface something meaningful.
         if not abs_text:
@@ -2444,6 +2467,25 @@ def backfill_paper_gaps():
         print(f"  ! backfill_paper_gaps failed: {e}")
 
 
+def normalize_paper_metadata():
+    """Normalize known duplicated LaTeX/text fragments in existing DB rows."""
+    try:
+        changed = 0
+        for paper in Paper.query.all():
+            for field in ("title", "abstract", "comments"):
+                current = getattr(paper, field) or ""
+                cleaned = _clean_arxiv_metadata_text(current)
+                if cleaned != current:
+                    setattr(paper, field, cleaned)
+                    changed += 1
+        if changed:
+            db.session.commit()
+            print(f"  [+] Normalized {changed} arXiv metadata fields")
+    except Exception as e:
+        db.session.rollback()
+        print(f"  ! normalize_paper_metadata failed: {e}")
+
+
 def ensure_affiliation_column():
     """Ensure the author_affiliations_json column exists on older DBs."""
     try:
@@ -2495,6 +2537,7 @@ with app.app_context():
     seed_database()
     seed_benchmark_users()
     backfill_paper_gaps()
+    normalize_paper_metadata()
     backfill_affiliations()
 
 

--- a/sites/arxiv/metadata_cleaning.py
+++ b/sites/arxiv/metadata_cleaning.py
@@ -1,0 +1,151 @@
+"""Metadata cleanup helpers for arXiv seed data."""
+
+import re
+
+
+_DUP_LATEX_FRAGMENT_RE = re.compile(
+    r"("
+    r"(?:\\[A-Za-z]+(?:\{[^{}]*\})?(?:[_^]\{?[^{}\s]+\}?)*)"
+    r"(?:=[0-9A-Za-z_.+-]+)?"
+    r"(?:\s*(?:\\times|\\rightarrow|to|-|\+)\s*)?"
+    r"(?:[A-Za-z0-9_.{}^+\-/]+)?"
+    r")\1"
+)
+_DUP_PLAIN_FRAGMENT_RE = re.compile(
+    r"\b([A-Za-z][A-Za-z0-9_.+-]{1,}(?:\s+[A-Za-z0-9_.+-]{1,}){0,5})\1\b"
+)
+_DUP_Z_VALUE_RE = re.compile(r"\b(z\s*=\s*[0-9.]+)\1\b")
+_DUP_ISOTOPE_RE = re.compile(r"(\^\{?\d+\}?)(?=\1)")
+_DUP_ION_PLUS_RE = re.compile(r"(\^[A-Za-z0-9_/{}+-]+)\+(?=\+)")
+_DUP_TIMES_EXPR_RE = re.compile(r"([A-Za-z]+\([^)]{1,30}\)\\times [A-Za-z]+\([^)]{1,30}\))\1")
+_DUP_ADJACENT_MATH_RE = re.compile(r"(\$[^$]{1,120}\$)\s*\1")
+_HREF_RE = re.compile(r"\\href\{([^{}]*)\}\{([^{}]*)\}")
+_URL_RE = re.compile(r"\\url\{([^{}]*)\}")
+
+_GREEK = {
+    "alpha": "α",
+    "beta": "β",
+    "gamma": "γ",
+    "delta": "δ",
+    "epsilon": "ε",
+    "lambda": "λ",
+    "mu": "μ",
+    "nu": "ν",
+    "phi": "φ",
+    "pi": "π",
+    "sigma": "σ",
+    "theta": "θ",
+    "upsilon": "υ",
+    "zeta": "ζ",
+}
+
+_SYMBOLS = {
+    "approx": "≈",
+    "bullet": "•",
+    "cdot": "·",
+    "epsilon": "ε",
+    "geq": "≥",
+    "gt": ">",
+    "gtrsim": "≥",
+    "in": "∈",
+    "infty": "∞",
+    "leq": "≤",
+    "log": "log",
+    "lt": "<",
+    "nabla": "∇",
+    "odot": "⊙",
+    "pm": "±",
+    "prime": "′",
+    "rightarrow": "→",
+    "sim": "∼",
+    "sqrt": "√",
+    "textendash": "–",
+    "times": "×",
+    "to": "→",
+}
+_SYMBOLS.update(_GREEK)
+
+
+def clean_arxiv_metadata_text(text):
+    """Repair scrape artifacts from mixed text/MathJax extraction."""
+    if not text:
+        return text
+    cleaned = re.sub(r"\s+", " ", str(text)).strip()
+    cleaned = _HREF_RE.sub(r"\2", cleaned)
+    cleaned = _URL_RE.sub(r"\1", cleaned)
+    previous = None
+    while cleaned != previous:
+        previous = cleaned
+        cleaned = _DUP_LATEX_FRAGMENT_RE.sub(r"\1", cleaned)
+        cleaned = _DUP_Z_VALUE_RE.sub(r"\1", cleaned)
+        cleaned = _DUP_TIMES_EXPR_RE.sub(r"\1", cleaned)
+        cleaned = _DUP_PLAIN_FRAGMENT_RE.sub(r"\1", cleaned)
+        cleaned = _DUP_ISOTOPE_RE.sub(r"\1", cleaned)
+        cleaned = _DUP_ION_PLUS_RE.sub(r"\1+", cleaned)
+    cleaned = re.sub(r"(\\mathcal\{N\}=)(\d+)\s+to\s+(\d+)", r"\1\2 to \3", cleaned)
+    cleaned = re.sub(r"\bCFT_(\d+)_(?=\d+\b)", r"CFT_", cleaned)
+    cleaned = re.sub(r"\bAdS_(\d+)_(?=\d+\b)", r"AdS_", cleaned)
+    if r"\gtrsim 100\times" in cleaned and "$" not in cleaned:
+        cleaned = cleaned.replace(r"\gtrsim 100\times", r"$\gtrsim 100\times$")
+    cleaned = re.sub(r"(?<!\$)\bz=([0-9]+(?:\.[0-9]+)?)(?!\$)", r"$z=\1$", cleaned)
+    previous = None
+    while cleaned != previous:
+        previous = cleaned
+        cleaned = _DUP_ADJACENT_MATH_RE.sub(r"\1", cleaned)
+    return cleaned
+
+
+def _replace_tex_command(match):
+    command = match.group(1)
+    braced = match.group(2)
+    if command in _SYMBOLS:
+        return _SYMBOLS[command] + (braced or "")
+    if command == "mathbb":
+        return braced or ""
+    if command == "mathcal":
+        return braced or ""
+    if command == "mathrm":
+        return braced or ""
+    if command == "mathbf":
+        return braced or ""
+    if command == "textbf":
+        return braced or ""
+    if command == "textit":
+        return braced or ""
+    if command == "textsc":
+        return (braced or "").upper()
+    if command == "texttt":
+        return braced or ""
+    if command == "emph":
+        return braced or ""
+    if command in {"operatorname", "mathsf", "mathit", "mathscr"}:
+        return braced or ""
+    if braced:
+        return braced
+    return "\\" + command
+
+
+def _format_math_text(expr):
+    expr = expr.replace(r"\,", "")
+    expr = expr.replace(r"\ ", " ")
+    expr = expr.replace("~", " ")
+    expr = re.sub(r"\\([A-Za-z]+)(?:\{([^{}]*)\})?", _replace_tex_command, expr)
+    expr = re.sub(r"\^\{([^{}]+)\}", r"^\1", expr)
+    expr = re.sub(r"_\{([^{}]+)\}", r"_\1", expr)
+    expr = expr.replace("{", "").replace("}", "")
+    expr = re.sub(r"\s+", " ", expr).strip()
+    return expr
+
+
+def format_arxiv_display_text(text):
+    """Return metadata text formatted for human-readable HTML display."""
+    if not text:
+        return text
+    formatted = clean_arxiv_metadata_text(text)
+    formatted = formatted.replace(r"\$", "$")
+    formatted = _HREF_RE.sub(r"\2", formatted)
+    formatted = _URL_RE.sub(r"\1", formatted)
+    formatted = re.sub(r"\$([^$]{1,240})\$", lambda m: _format_math_text(m.group(1)), formatted)
+    formatted = _format_math_text(formatted)
+    formatted = re.sub(r"\s+", " ", formatted).strip()
+    return formatted

--- a/sites/arxiv/templates/account.html
+++ b/sites/arxiv/templates/account.html
@@ -47,7 +47,7 @@
                 {% for item in recent_library %}
                 <li class="library-item">
                     <div class="lib-title">
-                        <a href="{{ url_for('paper_detail', arxiv_id=item.paper.arxiv_id) }}">{{ item.paper.title }}</a>
+                        <a href="{{ url_for('paper_detail', arxiv_id=item.paper.arxiv_id) }}">{{ item.paper.display_title }}</a>
                     </div>
                     <div class="lib-meta">{{ item.paper.authors_display }}</div>
                     <div class="lib-meta muted">

--- a/sites/arxiv/templates/author.html
+++ b/sites/arxiv/templates/author.html
@@ -21,7 +21,7 @@
         <a href="{{ url_for('format_view', arxiv_id=p.arxiv_id) }}">other</a>]
     </dt>
     <dd class="paper-entry">
-        <div class="entry-title"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.title }}</a></div>
+        <div class="entry-title"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.display_title }}</a></div>
         <div class="entry-authors"><b>Authors:</b> {{ p.authors_display }}</div>
         <div class="entry-subjects"><b>Subjects:</b> {{ p.primary_subject }}</div>
     </dd>

--- a/sites/arxiv/templates/category.html
+++ b/sites/arxiv/templates/category.html
@@ -44,18 +44,18 @@
         [<a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">abs</a>]
     </dt>
     <dd class="paper-entry">
-        <div class="entry-title"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.title }}</a></div>
+        <div class="entry-title"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.display_title }}</a></div>
         <div class="entry-authors"><b>Authors:</b>
             {% for a in p.get_authors()[:5] %}
                 <a href="{{ url_for('author_papers', name=a) }}">{{ a }}</a>{% if not loop.last %}, {% endif %}
             {% endfor %}
             {% if p.get_authors()|length > 5 %}, <i>et al.</i>{% endif %}
         </div>
-        {% if p.comments %}
-        <div class="entry-comments"><b>Comments:</b> {{ p.comments }}</div>
+        {% if p.display_comments %}
+        <div class="entry-comments"><b>Comments:</b> {{ p.display_comments }}</div>
         {% endif %}
         <div class="entry-subjects"><b>Subjects:</b> {{ p.primary_subject }}</div>
-        {% if p.abstract %}
+        {% if p.display_abstract %}
         <div class="entry-abs">{{ p.short_abstract }}</div>
         {% endif %}
     </dd>

--- a/sites/arxiv/templates/export_detail.html
+++ b/sites/arxiv/templates/export_detail.html
@@ -55,7 +55,7 @@
         {% for item in export.items %}
         <li class="library-item">
             <div class="lib-title">
-                <a href="{{ url_for('paper_detail', arxiv_id=item.paper.arxiv_id) }}">{{ item.paper.title }}</a>
+                <a href="{{ url_for('paper_detail', arxiv_id=item.paper.arxiv_id) }}">{{ item.paper.display_title }}</a>
             </div>
             <div class="lib-meta">{{ item.paper.authors_display }}</div>
             <div class="lib-meta muted">arXiv:{{ item.paper.arxiv_id }} · {{ item.paper.primary_subject }}</div>

--- a/sites/arxiv/templates/library.html
+++ b/sites/arxiv/templates/library.html
@@ -38,7 +38,7 @@
     {% for item in items %}
     <li class="library-item" data-lib-item="{{ item.id }}">
         <div class="lib-title">
-            <a href="{{ url_for('paper_detail', arxiv_id=item.paper.arxiv_id) }}">{{ item.paper.title }}</a>
+            <a href="{{ url_for('paper_detail', arxiv_id=item.paper.arxiv_id) }}">{{ item.paper.display_title }}</a>
         </div>
         <div class="lib-meta">{{ item.paper.authors_display }}</div>
         <div class="lib-meta muted">
@@ -54,7 +54,7 @@
                 <button type="submit" class="btn" style="font-size:11px;padding:1px 6px;">Save</button>
             </form>
         </div>
-        {% if item.paper.abstract %}
+        {% if item.paper.display_abstract %}
         <div class="lib-meta" style="margin-top:4px;">{{ item.paper.short_abstract }}</div>
         {% endif %}
         <div class="lib-actions">

--- a/sites/arxiv/templates/listing.html
+++ b/sites/arxiv/templates/listing.html
@@ -37,14 +37,14 @@
             <a href="{{ url_for('format_view', arxiv_id=p.arxiv_id) }}">other</a>]
         </dt>
         <dd class="paper-entry">
-            <div class="entry-title"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.title }}</a></div>
+            <div class="entry-title"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.display_title }}</a></div>
             <div class="entry-authors"><b>Authors:</b>
                 {% for a in p.get_authors() %}
                     <a href="{{ url_for('author_papers', name=a) }}">{{ a }}</a>{% if not loop.last %}, {% endif %}
                 {% endfor %}
             </div>
-            {% if p.comments %}
-            <div class="entry-comments"><b>Comments:</b> {{ p.comments }}</div>
+            {% if p.display_comments %}
+            <div class="entry-comments"><b>Comments:</b> {{ p.display_comments }}</div>
             {% endif %}
             <div class="entry-subjects"><b>Subjects:</b> {{ p.subjects }}</div>
         </dd>
@@ -61,14 +61,14 @@
         <a href="{{ url_for('format_view', arxiv_id=p.arxiv_id) }}">other</a>]
     </dt>
     <dd class="paper-entry">
-        <div class="entry-title"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.title }}</a></div>
+        <div class="entry-title"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.display_title }}</a></div>
         <div class="entry-authors"><b>Authors:</b>
             {% for a in p.get_authors() %}
                 <a href="{{ url_for('author_papers', name=a) }}">{{ a }}</a>{% if not loop.last %}, {% endif %}
             {% endfor %}
         </div>
-        {% if p.comments %}
-        <div class="entry-comments"><b>Comments:</b> {{ p.comments }}</div>
+        {% if p.display_comments %}
+        <div class="entry-comments"><b>Comments:</b> {{ p.display_comments }}</div>
         {% endif %}
         <div class="entry-subjects"><b>Subjects:</b> {{ p.subjects }}</div>
     </dd>

--- a/sites/arxiv/templates/paper.html
+++ b/sites/arxiv/templates/paper.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ paper.title }} — arXiv:{{ paper.arxiv_id }}{% endblock %}
+{% block title %}{{ paper.display_title }} — arXiv:{{ paper.arxiv_id }}{% endblock %}
 {% block breadcrumbs %}
     {% if paper.primary_category_code %}
     <span class="sep">&gt;</span>
@@ -29,7 +29,7 @@
         <div class="paper-label">
             {% if paper.submitted_date %}[Submitted on {{ paper.submitted_date }}]{% endif %}
         </div>
-        <h1 class="paper-title">{{ paper.title }}</h1>
+        <h1 class="paper-title">{{ paper.display_title }}</h1>
 
         <div class="paper-authors">
             {% for entry in paper.get_authors_with_affiliations() %}<a href="{{ url_for('author_papers', name=entry.name) }}">{{ entry.name }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
@@ -37,16 +37,16 @@
 
         <div class="paper-abstract">
             <span class="label">Abstract:</span>
-            {% if paper.abstract %}
-                {{ paper.abstract }}
+            {% if paper.display_abstract %}
+                {{ paper.display_abstract }}
             {% else %}
                 <i class="muted">Abstract not currently available for this paper.</i>
             {% endif %}
         </div>
 
         <div class="paper-meta">
-            {% if paper.comments %}
-            <div class="row"><span class="lab">Comments:</span> {{ paper.comments }}</div>
+            {% if paper.display_comments %}
+            <div class="row"><span class="lab">Comments:</span> {{ paper.display_comments }}</div>
             {% endif %}
             <div class="row"><span class="lab">Subjects:</span> {{ paper.subjects }}</div>
             {% set _versions = paper.get_versions() %}

--- a/sites/arxiv/templates/pdf_preview.html
+++ b/sites/arxiv/templates/pdf_preview.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ paper.title }} — PDF — arXiv{% endblock %}
+{% block title %}{{ paper.display_title }} — PDF — arXiv{% endblock %}
 {% block content %}
 
 <div style="margin:-12px -18px;">
@@ -10,7 +10,7 @@
 
     <div class="pdf-preview">
         <div class="pdf-page">
-            <h1>{{ paper.title }}</h1>
+            <h1>{{ paper.display_title }}</h1>
             <div class="pdf-authors">
                 {% for a in paper.get_authors() %}
                     {{ a }}{% if not loop.last %}, {% endif %}
@@ -23,8 +23,8 @@
 
             <div class="pdf-abstract-label">ABSTRACT</div>
             <div class="pdf-abstract">
-                {% if paper.abstract %}
-                    {{ paper.abstract }}
+                {% if paper.display_abstract %}
+                    {{ paper.display_abstract }}
                 {% else %}
                     <i>Abstract not currently available.</i>
                 {% endif %}
@@ -48,9 +48,9 @@
                 For citation purposes, please reference the arXiv identifier and version.
             </p>
 
-            {% if paper.comments %}
+            {% if paper.display_comments %}
             <h2 style="font-size:14px;">Notes</h2>
-            <p><i>{{ paper.comments }}</i></p>
+            <p><i>{{ paper.display_comments }}</i></p>
             {% endif %}
 
             <div style="margin-top:40px;padding-top:16px;border-top:1px solid #ccc;font-size:11px;">

--- a/sites/arxiv/templates/search.html
+++ b/sites/arxiv/templates/search.html
@@ -59,10 +59,10 @@
             <a href="{{ url_for('html_view', arxiv_id=p.arxiv_id) }}">html</a>,
             <a href="{{ url_for('format_view', arxiv_id=p.arxiv_id) }}">other</a>]
         </div>
-        <div class="rtitle"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.title }}</a></div>
+        <div class="rtitle"><a href="{{ url_for('paper_detail', arxiv_id=p.arxiv_id) }}">{{ p.display_title }}</a></div>
         <div class="rauthors">Authors: {{ p.authors_display }}</div>
         <div class="rsnippet">{{ p.short_abstract }}</div>
-        <div class="muted" style="font-size:11px;">{{ p.primary_subject }}{% if p.journal_ref %} &middot; {{ p.journal_ref }}{% endif %}{% if p.comments %} &middot; {{ p.comments }}{% endif %}</div>
+        <div class="muted" style="font-size:11px;">{{ p.primary_subject }}{% if p.display_journal_ref %} &middot; {{ p.display_journal_ref }}{% endif %}{% if p.display_comments %} &middot; {{ p.display_comments }}{% endif %}</div>
     </div>
     {% endfor %}
 

--- a/sites/arxiv/templates/starred.html
+++ b/sites/arxiv/templates/starred.html
@@ -10,13 +10,13 @@
     {% for item in items %}
     <li class="library-item">
         <div class="lib-title">
-            <a href="{{ url_for('paper_detail', arxiv_id=item.paper.arxiv_id) }}">{{ item.paper.title }}</a>
+            <a href="{{ url_for('paper_detail', arxiv_id=item.paper.arxiv_id) }}">{{ item.paper.display_title }}</a>
         </div>
         <div class="lib-meta">{{ item.paper.authors_display }}</div>
         <div class="lib-meta muted">
             arXiv:{{ item.paper.arxiv_id }} · Starred {{ item.starred_at.strftime("%b %d, %Y") }}
         </div>
-        {% if item.paper.abstract %}
+        {% if item.paper.display_abstract %}
         <div class="lib-meta" style="margin-top:4px;">{{ item.paper.short_abstract }}</div>
         {% endif %}
         <div class="lib-actions">


### PR DESCRIPTION
## Summary

Fixes arXiv metadata formatting issues caused by mixed text/MathJax extraction and raw TeX display.

This is broader than a single paper title: it normalizes duplicated LaTeX/math fragments at seed time and startup, and routes all user-facing arXiv title/abstract/comment/journal-ref displays through a shared formatter.

Examples handled:

- `\gtrsim 100\times\gtrsim 100\times` -> `≥ 100×` for display, and a single cleaned TeX fragment in stored metadata.
- `z=1.37z=1.37` -> `z=1.37` for display, and `$z=1.37$` in stored metadata.
- `\mathbb{P}^1\mathbb{P}^1` -> `P^1` for display.
- `\mathcal{N}=1\mathcal{N}=1` -> `N=1` for display.
- `GL(d_1)\times GL(d_2)GL(d_1)\times GL(d_2)` -> one `GL(d_1)× GL(d_2)` display fragment.
- Raw URL TeX commands such as `\url{...}` and `\href{...}{...}` no longer appear in displayed metadata.

Affected display surfaces now use display fields:

- abstract page
- search results
- category pages
- listing pages
- author pages
- account recent library
- library and starred pages
- export detail
- simulated PDF preview

BibTeX/export download paths keep the cleaned raw metadata instead of the display-formatted text.

Adds:

- `sites/arxiv/metadata_cleaning.py`
- `scripts/check_arxiv_metadata_latex.py`

## Verification

- `python3 scripts/check_arxiv_metadata_latex.py`
- `python3 -m py_compile sites/arxiv/app.py sites/arxiv/metadata_cleaning.py scripts/check_arxiv_metadata_latex.py`
- Flask test-client render checks across:
  - `/abs/2604.07983`
  - `/search?query=2025mkn&searchtype=all`
  - `/list/astro-ph.CO/recent`
  - `/category/astro-ph`
  - `/author/Lemon,%20Cameron`
- Verified rendered pages do not contain duplicated `\gtrsim 100\times\gtrsim 100\times`, adjacent duplicated math blocks, `z=1.37z=1.37`, `\url{...}`, or `\href{...}{...}`.

Fixes #16.
