### PR TITLE
Stabilize Booking filter fixtures

### DIFF
--- a/scripts/check_booking_filter_fixtures.py
+++ b/scripts/check_booking_filter_fixtures.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Regression checks for deterministic Booking filter fixtures."""
+
+import importlib.util
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOKING_DIR = ROOT / "sites/booking"
+
+
+def load_booking_app():
+    sys.path.insert(0, str(BOOKING_DIR))
+    os.chdir(BOOKING_DIR)
+    spec = importlib.util.spec_from_file_location("booking_app_for_fixture_check", BOOKING_DIR / "app.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    instance_dir = BOOKING_DIR / "instance"
+    if instance_dir.exists():
+        shutil.rmtree(instance_dir)
+    instance_dir.mkdir(exist_ok=True)
+
+    app = load_booking_app()
+    with app.app.app_context():
+        app.db.create_all()
+        app.seed_database()
+        city = app.City.query.filter_by(key="barcelona").first()
+        if not city:
+            raise SystemExit("missing Barcelona city fixture")
+
+        query = app.Property.query.filter_by(city_id=city.id)
+        query = query.filter(app.Property.breakfast_included.is_(True))
+        query = query.filter(app.Property.has_wifi.is_(True))
+        query = query.filter(app.Property.rating >= 8.0)
+        query = query.filter(app.Property.price_per_night >= 50)
+        query = query.filter(app.Property.price_per_night <= 500)
+        matches = query.order_by(app.Property.rating.desc(), app.Property.review_count.desc()).all()
+        if not matches:
+            raise SystemExit("Barcelona filter fixture produced no matching hotels")
+
+        for prop in matches:
+            if not (prop.breakfast_included and prop.has_wifi and prop.rating >= 8.0
+                    and 50 <= prop.price_per_night <= 500):
+                raise SystemExit(f"invalid matching hotel fixture: {prop.name}")
+
+        praktik = app.Property.query.filter_by(name="Praktik Èssens").first()
+        if not praktik:
+            raise SystemExit("missing Praktik Èssens fixture")
+        expected = {
+            "rating": 8.9,
+            "review_count": 83,
+            "price_per_night": 83.0,
+            "stars": 3,
+            "property_type": "Hotel",
+            "brand": "Independent",
+        }
+        for field, value in expected.items():
+            if getattr(praktik, field) != value:
+                raise SystemExit(f"Praktik Èssens {field}={getattr(praktik, field)!r}, expected {value!r}")
+        if not praktik.breakfast_included or not praktik.has_wifi:
+            raise SystemExit("Praktik Èssens must satisfy breakfast + WiFi filters")
+
+        hotel_brick = app.Property.query.filter_by(name="Hotel Brick Barcelona").first()
+        if hotel_brick and hotel_brick.breakfast_included and hotel_brick.has_wifi:
+            raise SystemExit("Hotel Brick Barcelona should not satisfy breakfast + WiFi filters")
+
+        print("Booking filter fixture checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/sites/booking/app.py
+++ b/sites/booking/app.py
@@ -4,6 +4,7 @@ import os
 import json
 import random
 import secrets
+import hashlib
 from datetime import datetime, timedelta, date
 from pathlib import Path
 
@@ -2135,7 +2136,9 @@ def seed_database():
 
     # Don't re-seed if already present
     if Property.query.first():
+        _ensure_amenity_combos()
         return
+    random.seed(20260518)
 
     # --- Categories ---
     for cat in DESTINATION_CATEGORIES:
@@ -2329,7 +2332,8 @@ def seed_database():
         else:
             # Deterministic pseudo-random brand assignment for variety
             brand_pool = ['Hilton', 'Marriott', 'Accor', 'IHG', 'Hyatt', 'Wyndham', 'Best Western', 'Independent', 'Independent', 'Independent']
-            brand = brand_pool[(abs(hash(name)) % len(brand_pool))]
+            brand_idx = int(hashlib.sha256(name.encode("utf-8")).hexdigest(), 16) % len(brand_pool)
+            brand = brand_pool[brand_idx]
 
         prop = Property(
             name=name,
@@ -2401,8 +2405,7 @@ def _ensure_amenity_combos():
         current = q.count()
         if current >= min_count:
             return
-        candidates = Property.query.filter_by(city_id=city.id).all()
-        random.shuffle(candidates)
+        candidates = Property.query.filter_by(city_id=city.id).order_by(Property.id.asc()).all()
         needed = min_count - current
         for prop in candidates:
             if needed <= 0:
@@ -2417,9 +2420,9 @@ def _ensure_amenity_combos():
     # Mexico City: discount_percent > 0
     city = City.query.filter_by(key='mexicocity').first()
     if city:
-        props = Property.query.filter_by(city_id=city.id).filter(Property.discount_percent == 0).limit(3).all()
-        for p in props:
-            p.discount_percent = random.choice([10, 15, 20])
+        props = Property.query.filter_by(city_id=city.id).filter(Property.discount_percent == 0).order_by(Property.id.asc()).limit(3).all()
+        for idx, p in enumerate(props):
+            p.discount_percent = [10, 15, 20][idx % 3]
             p.is_genius_deal = True
 
     # Varanasi: breakfast near Kashi Vishwanath
@@ -2519,6 +2522,23 @@ def _ensure_amenity_combos():
 
     # Barcelona: WiFi + breakfast
     _ensure_flags('barcelona', {'has_wifi': True, 'breakfast_included': True}, min_count=3)
+    praktik = Property.query.filter_by(name='Praktik Èssens').first()
+    if praktik:
+        praktik.has_wifi = True
+        praktik.breakfast_included = True
+        praktik.rating = 8.9
+        praktik.rating_label = rating_label_for(praktik.rating)
+        praktik.review_count = 83
+        praktik.price_per_night = 83.0
+        praktik.discount_percent = 0
+        praktik.stars = 3
+        praktik.property_type = 'Hotel'
+        praktik.distance_from_center = 1.9
+        praktik.brand = 'Independent'
+    hotel_brick = Property.query.filter_by(name='Hotel Brick Barcelona').first()
+    if hotel_brick:
+        hotel_brick.breakfast_included = False
+        hotel_brick.has_wifi = False
 
     # Lisbon: airport shuttle + 8.5+ + breakfast
     city = City.query.filter_by(key='lisbon').first()


### PR DESCRIPTION
## Summary

Makes Booking filter fixtures deterministic and ensures the Barcelona breakfast/WiFi/rating/price task has a stable valid property fixture.

Root cause found during investigation:

- Booking seed generation used process-random state for prices, ratings, amenities, review counts, flags, and distances.
- Brand fallback used Python's randomized `hash(name)`, which changes across processes.
- `Hotel Brick Barcelona` could be selected by an agent but does not satisfy `breakfast_included` + `has_wifi`.
- Evaluator expectations referenced `Praktik Èssens`, but that property was not guaranteed to satisfy all requested filters in every seed.

Changes:

- Set a fixed seed for Booking seed generation.
- Replace Python `hash(name)` brand fallback with stable SHA-256 based assignment.
- Ensure targeted amenity combo normalization runs even against an existing packaged DB.
- Stabilize `Praktik Èssens` as a valid Barcelona filter fixture:
  - rating `8.9`
  - review count `83`
  - nightly price `83.0`
  - breakfast included
  - free WiFi
  - brand `Independent`
- Ensure `Hotel Brick Barcelona` does not accidentally satisfy breakfast + WiFi filters.
- Add `scripts/check_booking_filter_fixtures.py`.

## Verification

- `uv run ... python scripts/check_booking_filter_fixtures.py`
- `python3 -m py_compile sites/booking/app.py scripts/check_booking_filter_fixtures.py`
- Re-seeded twice from a clean DB and verified the Barcelona filtered result set is deterministic.

Fixes #27.
